### PR TITLE
Update GitHub Actions workflow dependencies and improve caching

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,32 +14,20 @@ jobs:
     name: Deploy to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          run_install: false
-          version: 8
+          version: 10
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: ./build.sh


### PR DESCRIPTION
## Summary
Updated the deploy-pages workflow to use the latest versions of GitHub Actions and improved the dependency caching strategy for better performance and reliability.

## Key Changes
- **Action versions**: Updated `actions/checkout` (v3 → v4), `actions/setup-node` (v3 → v4), and `pnpm/action-setup` (v2 → v4)
- **pnpm version**: Bumped from v8 to v10
- **Simplified caching**: Replaced manual pnpm store path caching with the built-in `cache: pnpm` option in `actions/setup-node@v4`
- **Removed unnecessary steps**: Eliminated the "Get pnpm store directory" step as it's now handled automatically
- **Enhanced install command**: Changed `pnpm install` to `pnpm install --frozen-lockfile` for stricter dependency resolution

## Implementation Details
The refactored workflow is more maintainable and leverages native caching support in the newer `setup-node` action, which automatically handles pnpm cache management. This reduces boilerplate configuration while maintaining the same caching benefits. The `--frozen-lockfile` flag ensures reproducible builds by preventing any modifications to the lock file during installation.

https://claude.ai/code/session_01VxK9a8dzuf5CJEENWBPxvW