### PR TITLE
Update current employer from Anthropic to stealth startup

### DIFF
--- a/src/assets/data/achievements.json
+++ b/src/assets/data/achievements.json
@@ -7,5 +7,6 @@
   {"category": "Politics", "description": "Made a Public Comment at SF City Hall", "achieved_on": "2025-04-10"},
   {"category": "Politics", "description": "Mentioned in the Washington Post", "achieved_on": "2025-04-11", "url": "https://www.washingtonpost.com/nation/2025/04/11/authoritarian-countries-dictators-trump-administration/"},
   {"category": "Games", "description": "Trackmania: Bonk Cup Server 6 Finalist", "achieved_on": "2025-05-01"},
+  {"category": "Technology", "description": "Case study published on Anthropic blog", "achieved_on": "2025-04-18", "url": "https://www.anthropic.com/customers/semgrep"},
   {"category": "Predictions", "description": "Manifold Markets: Promoted to Masters League", "achieved_on": "2025-05-01", "url": "https://manifold.markets/leagues/24/diamond/ultra-cranes"}
 ]

--- a/src/assets/data/achievements.json
+++ b/src/assets/data/achievements.json
@@ -7,6 +7,5 @@
   {"category": "Politics", "description": "Made a Public Comment at SF City Hall", "achieved_on": "2025-04-10"},
   {"category": "Politics", "description": "Mentioned in the Washington Post", "achieved_on": "2025-04-11", "url": "https://www.washingtonpost.com/nation/2025/04/11/authoritarian-countries-dictators-trump-administration/"},
   {"category": "Games", "description": "Trackmania: Bonk Cup Server 6 Finalist", "achieved_on": "2025-05-01"},
-  {"category": "Technology", "description": "Case study published on Anthropic blog", "achieved_on": "2025-04-18", "url": "https://www.anthropic.com/customers/semgrep"},
   {"category": "Predictions", "description": "Manifold Markets: Promoted to Masters League", "achieved_on": "2025-05-01", "url": "https://manifold.markets/leagues/24/diamond/ultra-cranes"}
 ]

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,8 +2,7 @@
   <section style={{ textAlign: "left" }}>
     <div>Bence Nagy (underyx)</div>
     <div>
-      Technical Staff @{" "}
-      <a href="https://anthropic.com/">Anthropic</a>
+      Technical Staff @ a stealth startup
     </div>
     <div>
       <a href="https://nomadlist.com/@underyx">San Francisco, CA</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,12 +2,11 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="home" description="Bence Nagy (underyx) - Software engineer at Anthropic. Interested in rationality, video games, and design. Get in touch with your hardest problems!">
+<Layout title="home" description="Bence Nagy (underyx) - Software engineer at a stealth startup. Interested in rationality, video games, and design. Get in touch with your hardest problems!">
   <p>Heya! Introductions are hard, we can get right to it.</p>
   <p>
     I&rsquo;m Bence Nagy. I usually go by &lsquo;underyx&rsquo; online.
-    Currently working at{" "}
-    <a href="https://anthropic.com">Anthropic</a> as a Member of Technical Staff.
+    Currently working at a stealth startup as a Member of Technical Staff.
   </p>
   <p>
     I keep getting lost in trying new things. But a couple interests that have

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -7,7 +7,7 @@ import { Image } from "astro:assets";
 import avatarImage from "../assets/avatar-2020.jpg";
 ---
 
-<Layout title="résumé" description="Bence Nagy's résumé - Member of Technical Staff at Anthropic. Previously Staff Engineer at Semgrep, Software Platform Lead at Kiwi.com. Python, DevOps, and engineering culture expert.">
+<Layout title="résumé" description="Bence Nagy's résumé - Member of Technical Staff at a stealth startup. Previously Staff Engineer at Semgrep, Software Platform Lead at Kiwi.com. Python, DevOps, and engineering culture expert.">
   <section class="header">
     <div class="title">
       <h2>Bence Nagy&rsquo;s Résumé</h2>
@@ -22,10 +22,9 @@ import avatarImage from "../assets/avatar-2020.jpg";
     </div>
   </section>
 
-  <h3>Work at Anthropic (2025-)</h3>
+  <h3>Work at a Stealth Startup (2025-)</h3>
   <p>
-    Engineering at {" "}
-    <a href="https://anthropic.com">Anthropic</a>!
+    Engineering at a stealth startup!
   </p>
   <h4>Role</h4>
   <ul>


### PR DESCRIPTION
## Summary
Updates all references to current employment from Anthropic to a generic "stealth startup" designation across the site's public-facing pages and components.

## Changes Made
- **Resume page** (`src/pages/resume.astro`):
  - Updated page description meta tag to reference "stealth startup" instead of Anthropic
  - Changed work section heading from "Work at Anthropic (2025-)" to "Work at a Stealth Startup (2025-)"
  - Removed Anthropic link and replaced descriptive text with generic "Engineering at a stealth startup!"

- **Home page** (`src/pages/index.astro`):
  - Updated page description meta tag to reference "stealth startup" instead of Anthropic
  - Removed Anthropic link from employment description
  - Changed text to "Currently working at a stealth startup as a Member of Technical Staff"

- **Footer component** (`src/components/Footer.astro`):
  - Removed Anthropic link from footer
  - Changed footer text from "Technical Staff @ Anthropic" to "Technical Staff @ a stealth startup"

## Notes
All changes maintain the same role title (Member of Technical Staff) while removing specific company identification and associated links.

https://claude.ai/code/session_01AFAzxWmHZ4iXM46bAbZtj5