### PR TITLE
Add Discogs profile link to social links

### DIFF
--- a/src/assets/data/links.json
+++ b/src/assets/data/links.json
@@ -93,6 +93,11 @@
         "note": "on the way to reaching 10,000 artists listened"
       },
       {
+        "name": "Discogs",
+        "url": "https://www.discogs.com/user/underyx",
+        "note": "keeping track of the records I've collected"
+      },
+      {
         "name": "trakt.tv",
         "url": "https://trakt.tv/users/underyx",
         "note": "cool charts about movies and TV shows watched"

--- a/src/assets/data/links.json
+++ b/src/assets/data/links.json
@@ -95,7 +95,7 @@
       {
         "name": "Discogs",
         "url": "https://www.discogs.com/user/underyx",
-        "note": "keeping track of the records I've collected"
+        "note": "i'm a record holder"
       },
       {
         "name": "trakt.tv",


### PR DESCRIPTION
## Summary
Added a new link to the user's Discogs profile in the social links data file.

## Changes
- Added Discogs profile entry to `src/assets/data/links.json` with:
  - Profile URL: https://www.discogs.com/user/underyx
  - Description note about tracking collected records
  - Positioned between Last.fm and trakt.tv entries

## Details
The new entry follows the existing link structure with `name`, `url`, and `note` fields, maintaining consistency with other social profile links in the file.

https://claude.ai/code/session_01Eq1kQyPf3KZ9pYrfxUZNch